### PR TITLE
Accept context as positional parameters and also from the standard input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Felipe S. S. Schneider <schneider.felipe.5@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"
-description = "A command-line interface for ChatGPT"
+description = "A command-line interface to talk to ChatGPT"
 repository = "https://github.com/schneiderfelipe/cligpt"
 license = "MIT"
 


### PR DESCRIPTION
This allows the following:

```console
$ echo "(a nice one)." | cligpt Tell me a joke
Why did the tomato turn red?

Because it saw the salad dressing!
```

What ChatGPT sees is

```
Tell me a joke (a nice one).
```

That is, positional arguments come before the standard input, and everything is single-space joined.